### PR TITLE
Top 10 sprint plan, biweekly call details, and README links

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ The project runs expert-backed and community-driven, with open and transparent
 peer review and project-lead sign-off. Additional working-group and entry leads
 are being onboarded as the project matures.
 
+See the [project charter](charter.md) for the mission, scope, governance, and
+ways of working.
+
 ---
 
 ## The OWASP Top 10 for Quantum Security Risks
@@ -89,10 +92,14 @@ standards-and-regulatory mapping.
 
 ## Community calls
 
-The project runs a monthly community call, with additional calls on demand as the
-work picks up. Decks for every call are published in [`calls/`](calls/), starting
-with the project kick-off deck; decks for subsequent calls are added there as they
-happen.
+The project runs a biweekly community call (Mondays 17:30-18:30 London, starting
+3 August 2026 - see [Community and contact](#community-and-contact) for the Zoom
+and calendar details), with additional calls on demand as the work picks up. Decks
+for every call are published in [`calls/`](calls/), starting with the project
+kick-off deck; decks for subsequent calls are added there as they happen.
+
+The route from the v0.1 draft to a community-validated v1 is laid out in the
+[sprint plan and project timeline](plans/sprint-plan-quantum-top10-2026.md).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ During the bootstrap phase you can also contribute via these forms without using
 - **Homepage:** [quantum-owasp.org](https://quantum-owasp.org)
 - **GitHub:** [github.com/OWASP/quantum-security-project](https://github.com/OWASP/quantum-security-project)
 - **OWASP Slack:** `#project-quantum-security` - [join the OWASP Slack](https://owasp.org/slack/invite)
+- **Biweekly community call:** Mondays 17:30-18:30 (London / Europe/London), every two weeks starting **3 August 2026**, on Zoom - [join](https://deepcyberx.zoom.us/j/87321791672?pwd=pDq33o7cwIca0h32amjpOb4vQkSQFk.1) (Meeting ID `873 2179 1672`, passcode `701551`). Add to your calendar: [ICS invite](calls/OWASPQuantumBiweeklyCall.ics).
 - **Email:** contribute@quantum-owasp.org
 
 The project follows OWASP's standard documentation and contribution practices,

--- a/calls/OWASPQuantumBiweeklyCall.ics
+++ b/calls/OWASPQuantumBiweeklyCall.ics
@@ -1,0 +1,65 @@
+BEGIN:VCALENDAR
+PRODID:-//Google Inc//Google Calendar 70.9054//EN
+VERSION:2.0
+CALSCALE:GREGORIAN
+METHOD:REQUEST
+BEGIN:VTIMEZONE
+TZID:Europe/London
+X-LIC-LOCATION:Europe/London
+BEGIN:DAYLIGHT
+TZOFFSETFROM:+0000
+TZOFFSETTO:+0100
+TZNAME:GMT+1
+DTSTART:19700329T010000
+RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU
+END:DAYLIGHT
+BEGIN:STANDARD
+TZOFFSETFROM:+0100
+TZOFFSETTO:+0000
+TZNAME:GMT
+DTSTART:19701025T020000
+RRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU
+END:STANDARD
+END:VTIMEZONE
+BEGIN:VEVENT
+DTSTART;TZID=Europe/London:20260803T173000
+DTEND;TZID=Europe/London:20260803T183000
+RRULE:FREQ=WEEKLY;WKST=SU;INTERVAL=2;BYDAY=MO
+DTSTAMP:20260721T112319Z
+ORGANIZER;CN=John Sotiropoulos:mailto:john.sotiropoulos@owasp.org
+UID:6pbv3voqq0jc8a4jemjfgltnr4@google.com
+ATTENDEE;CUTYPE=INDIVIDUAL;ROLE=REQ-PARTICIPANT;PARTSTAT=ACCEPTED;RSVP=TRUE
+ ;CN=John Sotiropoulos;X-NUM-GUESTS=0:mailto:john.sotiropoulos@owasp.org
+ATTENDEE;CUTYPE=INDIVIDUAL;ROLE=REQ-PARTICIPANT;PARTSTAT=NEEDS-ACTION;RSVP=
+ TRUE;CN=john@deepcyber.ai;X-NUM-GUESTS=0:mailto:john@deepcyber.ai
+ATTENDEE;CUTYPE=INDIVIDUAL;ROLE=REQ-PARTICIPANT;PARTSTAT=NEEDS-ACTION;RSVP=
+ TRUE;CN=Roy Barkay;X-NUM-GUESTS=0:mailto:roy.barkay@owasp.org
+X-MICROSOFT-CDO-OWNERAPPTID:618431907
+CREATED:20260721T112051Z
+DESCRIPTION:<p><br>──────────<br><br>John Sotiropoulos is inviting you to a
+  scheduled Zoom meeting.<br>Join Zoom Meeting<br>https://deepcyberx.zoom.us
+ /j/87321791672?pwd=pDq33o7cwIca0h32amjpOb4vQkSQFk.1<br><br>Meeting agenda<b
+ r>https://docs.zoom.us/agenda/doc/9d2dc494-0c24-45a9-91ca-d1a18689f133?from
+ =chext<br><br>Meeting chat link<br>https://deepcyberx.zoom.us/launch/jc/873
+ 21791672<br><br>View meeting insights<br>https://deepcyberx.zoom.us/launch/
+ edl?muid=9d2dc494-0c24-45a9-91ca-d1a18689f133&amp\;from=chext<br><br>Meetin
+ g ID: 873 2179 1672<br>Passcode: 701551<br><br>---<br><br>One tap mobile<br
+ >+13126266799\,\,87321791672#\,\,\,\,*701551# US (Chicago)<br>+13462487799\
+ ,\,87321791672#\,\,\,\,*701551# US (Houston)<br><br><br>---<br><br>Join by 
+ SIP<br>• 87321791672@zoomcrc.com<br><br>Join instructions<br>https://deepcy
+ berx.zoom.us/meetings/87321791672/invitations?signature=x548_I4vkytbai6T91B
+ Vf3nJP5krSJB9SYFUL5tA_mY<br><br><br><br>──────────</p>
+LAST-MODIFIED:20260721T112307Z
+LOCATION:https://deepcyberx.zoom.us/j/87321791672?pwd=pDq33o7cwIca0h32amjpO
+ b4vQkSQFk.1&jst=3
+SEQUENCE:1
+STATUS:CONFIRMED
+SUMMARY:OWASP Quantum Security Project - Biweekly call
+TRANSP:TRANSPARENT
+BEGIN:VALARM
+ACTION:DISPLAY
+DESCRIPTION:This is an event reminder
+TRIGGER:-P0DT0H10M0S
+END:VALARM
+END:VEVENT
+END:VCALENDAR


### PR DESCRIPTION
## Summary

Brings the sprint plan and call/README updates into `main`:

- **Sprint plan** — adds `plans/sprint-plan-quantum-top10-2026.md`, the v0.1 → v1 roadmap (Pre-Sprint 0 through publication w/c 26 Oct 2026).
- **Biweekly community call** — adds `calls/OWASPQuantumBiweeklyCall.ics` and documents the call in the README (Mondays 17:30–18:30 London, every two weeks starting 3 August 2026, with Zoom and calendar details).
- **README links** — links the project charter (`charter.md`) and the sprint plan, which were previously undiscoverable from the README; updates the community-call cadence from monthly to biweekly.

## Files changed
- `plans/sprint-plan-quantum-top10-2026.md` (new)
- `calls/OWASPQuantumBiweeklyCall.ics` (new)
- `README.md`