### PR TITLE
Verify all references; correct QS08 attribution and QS05 stale draft

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ workloads on quantum computing platforms.
 | [QS05](quantum-top-10/QS05_Crypto-Agility-Failures.md) | Crypto-Agility Failures | NIS2 Article 21(2)(h); IETF PQUIP/TLS WG |
 | [QS06](quantum-top-10/QS06_Insecure-Migration-and-Hybrid-Misuse.md) | Insecure Migration and Hybrid Misuse | EU Roadmap end-2030 standalone-classical prohibition |
 | [QS07](quantum-top-10/QS07_Hardware-Roots-of-Trust.md) | Hardware Roots of Trust | NCSC 2028 milestone; CRA Annex IV |
-| [QS08](quantum-top-10/QS08_QPU-Tenant-Isolation-Failures.md) | QPU Tenant Isolation Failures | Li et al. NDSS 2025; Xu et al. CCS 2023 |
+| [QS08](quantum-top-10/QS08_QPU-Tenant-Isolation-Failures.md) | QPU Tenant Isolation Failures | Choudhury et al. NDSS 2025; Xu et al. CCS 2023 |
 | [QS09](quantum-top-10/QS09_Toolchain-and-Compiler-Compromise.md) | Toolchain and Compiler Compromise | Suresh et al. HASP 2021; Chu et al. ICASSP 2023 |
 | [QS10](quantum-top-10/QS10_Side-Channel-and-Control-Plane-Exposure.md) | Side-Channel and Control-Plane Exposure | Mi et al. CCS 2022; Xu et al. CCS 2023 |
 

--- a/quantum-top-10/QS05_Crypto-Agility-Failures.md
+++ b/quantum-top-10/QS05_Crypto-Agility-Failures.md
@@ -29,13 +29,13 @@ Scenario #2: A team adds a crypto abstraction layer but never tests rotation. Wh
 
 **Reference Links:**
 
-<!-- References verified 2026-07-13 against authoritative canonical sources. NCSC has no standalone crypto-agility page; the PQC migration timelines page is the appropriate anchor. -->
+<!-- References verified 2026-07-27 against authoritative primary sources. NCSC has no standalone crypto-agility page; the PQC migration timelines page is the appropriate anchor, and its 2028/2031/2035 milestones were confirmed against the live page. Reference #5 updated: draft-ietf-tls-hybrid-design was published as RFC 9954 in July 2026. -->
 
 1. [CISA, NSA, NIST - Quantum-Readiness fact sheet](https://www.cisa.gov/resources-tools/resources/quantum-readiness-migration-post-quantum-cryptography): Cryptographic agility recommendation.
 2. [UK NCSC - Timelines for migration to post-quantum cryptography](https://www.ncsc.gov.uk/guidance/pqc-migration-timelines): Agility expectations within PQC migration guidance.
 3. [EU Coordinated Implementation Roadmap for PQC](https://digital-strategy.ec.europa.eu/en/library/coordinated-implementation-roadmap-transition-post-quantum-cryptography): Explicit agility expectation.
 4. [IETF PQUIP Working Group](https://datatracker.ietf.org/wg/pquip/about/): Agility documents and migration patterns.
-5. [IETF - Hybrid key exchange in TLS 1.3 (draft-ietf-tls-hybrid-design)](https://datatracker.ietf.org/doc/draft-ietf-tls-hybrid-design/): Hybrid KEM negotiation.
+5. [RFC 9954 - Hybrid Key Exchange in TLS 1.3](https://www.rfc-editor.org/info/rfc9954): Hybrid KEM negotiation (Informational, July 2026). Supersedes `draft-ietf-tls-hybrid-design`.
 
 **Standards and Regulatory Mapping:**
 

--- a/quantum-top-10/QS08_QPU-Tenant-Isolation-Failures.md
+++ b/quantum-top-10/QS08_QPU-Tenant-Isolation-Failures.md
@@ -21,15 +21,15 @@ Cloud-based quantum platforms increasingly host workloads from multiple tenants 
 
 **Example Attack Scenarios:**
 
-Scenario #1: A financial firm runs a proprietary optimisation circuit on a shared QPU. A malicious co-tenant schedules a circuit adjacent on the QPU topology and uses quantum crosstalk to degrade the victim's fidelity (Li et al., NDSS 2025; Ash-Saki et al., ISLPED 2020), corrupting results the firm relies on - without ever needing co-execution.
+Scenario #1: A financial firm runs a proprietary optimisation circuit on a shared QPU. A malicious co-tenant schedules a circuit adjacent on the QPU topology and uses quantum crosstalk to degrade the victim's fidelity (Choudhury et al., NDSS 2025; Ash-Saki et al., ISLPED 2020), corrupting results the firm relies on - without ever needing co-execution.
 
 Scenario #2: A tenant's circuit is scheduled on physical qubits immediately after a competitor's workload. Because standard reset gates do not fully clear state (Xu et al., CCS 2023), the tenant observes residual state leaking information about the previous, confidential computation.
 
 **Reference Links:**
 
-<!-- References verified 2026-07-13. Academic citations corrected to real papers; "Choudhury et al." was a mis-citation and is corrected to Li et al. (see #1). -->
+<!-- References verified 2026-07-27 against authoritative primary sources. Reference #1 is attributed to "Choudhury et al.": the paper's first author is Navnil Choudhury, confirmed against the arXiv metadata API for 2412.10507 and the NDSS proceedings PDF (13C-f2185-choudhury.pdf). Recorded here so the attribution is not changed again. -->
 
-1. [Li et al. - Crosstalk-induced Side Channel Threats in Multi-Tenant NISQ Computers (NDSS 2025)](https://www.ndss-symposium.org/ndss-paper/crosstalk-induced-side-channel-threats-in-multi-tenant-nisq-computers/): Demonstrated crosstalk-based side-channel/fidelity attack on shared QPUs. (Corrects the earlier "Choudhury et al." mis-citation; arXiv:2412.10507.)
+1. [Choudhury et al. - Crosstalk-induced Side Channel Threats in Multi-Tenant NISQ Computers (NDSS 2025)](https://www.ndss-symposium.org/ndss-paper/crosstalk-induced-side-channel-threats-in-multi-tenant-nisq-computers/): Demonstrated crosstalk-based side-channel/fidelity attack on shared QPUs ([arXiv:2412.10507](https://arxiv.org/abs/2412.10507)).
 2. [Ash-Saki et al. - Analysis of Crosstalk in NISQ Devices and Security Implications in Multi-Programming Regime (ISLPED 2020)](https://doi.org/10.1145/3370748.3406570): Crosstalk-based fault injection.
 3. [Xu et al. - Securing NISQ Quantum Computer Reset Operations Against Higher Energy State Attacks (CCS 2023)](https://doi.org/10.1145/3576915.3623104): Documents reset-operation state leakage across the tenant boundary.
 4. [EU DORA - Regulation (EU) 2022/2554, Article 28](https://eur-lex.europa.eu/eli/reg/2022/2554/oj/eng): Third-party ICT risk expectation that platform claims are evidenced.
@@ -38,5 +38,5 @@ Scenario #2: A tenant's circuit is scheduled on physical qubits immediately afte
 
 > **TODO:** This section is carried over from the source document and is not part of `_template.md`. Confirm whether to keep it in the final entry format, and verify each standard/citation.
 
-No formal standard yet covers QPU tenant isolation. NIST and NCSC have not published guidance on quantum platform security. The relevant published research includes Li et al. on crosstalk-induced side-channel threats (NDSS 2025), Ash-Saki et al. on crosstalk-based fault injection (ISLPED 2020), and Xu et al. on reset-operation state leakage (CCS 2023). Where DORA Article 28 third-party risk applies to financial entities using quantum platform services, the supervisory expectation is that platform security claims are evidenced rather than assumed.
+No formal standard yet covers QPU tenant isolation. NIST and NCSC have not published guidance on quantum platform security. The relevant published research includes Choudhury et al. on crosstalk-induced side-channel threats (NDSS 2025), Ash-Saki et al. on crosstalk-based fault injection (ISLPED 2020), and Xu et al. on reset-operation state leakage (CCS 2023). Where DORA Article 28 third-party risk applies to financial entities using quantum platform services, the supervisory expectation is that platform security claims are evidenced rather than assumed.
 


### PR DESCRIPTION
A verification pass over every reference in the list: all 29 unique links across
the ten entries, checked against primary sources rather than link-checked. Two
corrections result. Everything else held up.

## Correction 1 - QS08 attribution

The crosstalk paper is attributed to **Choudhury et al.**

The author list is **Navnil Choudhury**, Chaithanya Naik Mude, Sanjay Das,
Preetham Chandra Tikkireddi, Swamit Tannu, Kanad Basu. Confirmed three
independent ways:

- The arXiv metadata API for `2412.10507` - the identifier the entry already cites.
- The NDSS proceedings PDF, filed as `13C-f2185-choudhury.pdf`.
- The NDSS paper page author list.

Attribution on this one looks genuinely easy to get turned around, so the
verification comment now records the evidence inline - the intent being that the
next person to check it has the sources to hand and does not need to change it
again. The fix touches four places in QS08 and the QS08 row of the README table.

## Correction 2 - QS05 stale draft

`draft-ietf-tls-hybrid-design` was published as **RFC 9954** (Informational, July
2026). QS05 reference #5 now points at the RFC. This is the same fix already noted
in #17 and #12; QS05 was the remaining occurrence.

## What was checked and found correct

- **All six academic DOIs** (QS08, QS09, QS10) resolve to publications whose title,
  first author, venue and year match the entry exactly, verified via Crossref
  metadata. The platform-surface citations are in good shape.
- **NCSC PQC migration timelines** - the 2028 discovery, 2031 early-priority and
  2035 completion milestones all match the live page, as does the statement that
  new PQC standards are needed for TPMs, X.509 PKI, UEFI Secure Boot and 6G. Cited
  by four entries; all four uses are accurate.
- **NIST IR 8547** is correctly cited as an initial public draft. It has not been
  finalised, so the existing `(Draft)` qualifier should stay.
- **All 29 links resolve.** Several return 403 to automated requests - nsa.gov,
  cisa.gov, ACM DOIs, trustedcomputinggroup.org - but load normally in a browser.
  Worth recording so a future automated check does not report them as broken.

## Note on method

Link-checking would not have caught either correction: both URLs return 200 and
always did. The RFC 9954 change is invisible unless the target is read, and the
attribution error is only visible in the paper's own metadata. This is the
practice the evidence convention in #18 describes - verify the target, not the
link - so this PR is partly a demonstration that it finds real defects.

No entry text is changed apart from the two citations and the comments recording
what was verified.
