### PR TITLE
awesomelist: fix SLH-DSA standard number (FIPS 205, not 204)

### DIFF
--- a/awesomelist/README.md
+++ b/awesomelist/README.md
@@ -2,7 +2,7 @@
 
 > Useful resources for Post-Quantum Cryptography 
 
-Post-Quantum Cryptography is the field of cyber security concerned with updating cryptographic systems to achieve quantum resistance, remaining secure once powerful quantum computers have beeen created.
+Post-Quantum Cryptography is the field of cyber security concerned with updating cryptographic systems to achieve quantum resistance, remaining secure once powerful quantum computers have been created.
 
 
 ## Contents
@@ -19,7 +19,7 @@ Post-Quantum Cryptography is the field of cyber security concerned with updating
 
 Tools and resources that assist with the creation of cryptographic inventories, used to help guide PQC migrations.
 
-- [open-crypto-rules](https://github.com/scanoss/open-crypto-rules) - Open source Semgrep/OpenGrep rules for detecting cryptographic usage in source code (cuurently C, Go & Rust).
+- [open-crypto-rules](https://github.com/scanoss/open-crypto-rules) - Open source Semgrep/OpenGrep rules for detecting cryptographic usage in source code (currently C, Go & Rust).
 - [pq-audit](http://github.com/mk-scorpiosec/pq-audit) - A tool that evaluates cryptographic posture, infrastructure configuration, and code against NIST PQC standards.
 
 

--- a/awesomelist/README.md
+++ b/awesomelist/README.md
@@ -35,7 +35,7 @@ Tools and resources that assist with the creation of cryptographic inventories, 
 - [NIST PQC Standardisation Homepage](https://csrc.nist.gov/projects/post-quantum-cryptography) - Home page for NIST's PQC standardisation project.
 - [NIST Standard: ML-KEM](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.203.pdf) - FIPS 203, Module-Lattice-Based Key-Encapsulation Mechanism Standard (ML-KEM).
 - [NIST Standard: ML-DSA](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.204.pdf) - FIPS 204, Module-Lattice-Based Digital Signature Standard (ML-DSA).
-- [NIST Standard: SLH-DSA](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.205.pdf) - FIPS 204, Stateless Hash-Based Digital Signature Standard (SLH-DSA).
+- [NIST Standard: SLH-DSA](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.205.pdf) - FIPS 205, Stateless Hash-Based Digital Signature Standard (SLH-DSA).
 
 
 ## Test & Validation


### PR DESCRIPTION
## B. Gap A — FIPS-205 fix in the awesomelist  [VERIFIED — new one-line PR]

**PR title:** `awesomelist: fix SLH-DSA standard number (FIPS 205, not 204)`

**PR body:**
> `awesomelist/README.md` labels SLH-DSA as "FIPS 204", but SLH-DSA is standardised in **FIPS 205** (FIPS 204 is
> ML-DSA, correctly listed on the line above). The hyperlink on the same line already points to the FIPS 205 PDF,
> so only the text label is wrong. QS03 also references "NIST FIPS 205 (SLH-DSA)", so this aligns the awesomelist
> with the entries.


**Exact change (line 38):**
```
- - [NIST Standard: SLH-DSA](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.205.pdf) - FIPS 204, Stateless Hash-Based Digital Signature Standard (SLH-DSA).
+ - [NIST Standard: SLH-DSA](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.205.pdf) - FIPS 205, Stateless Hash-Based Digital Signature Standard (SLH-DSA).
```

---
