### PR TITLE
chore: update HAWK knowledge base entry after withdrawal

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,13 @@ Each entry follows a common [template](quantum-top-10/_template.md): description
 common examples, prevention, example attack scenarios, references, and a
 standards-and-regulatory mapping.
 
+### Supporting evidence
+
+New research, disclosed vulnerabilities, and cryptanalysis findings used to
+review the Top 10 are recorded in the [quantum security knowledge
+base](knowledgebase/README.md). It is a dated evidence-intake log mapped to the
+Top 10, not a replacement for the reviewed Top 10 guidance.
+
 ---
 
 ## Community calls

--- a/knowledgebase/README.md
+++ b/knowledgebase/README.md
@@ -15,19 +15,50 @@ Maintainer: Vishnu Ajith (@Vishnu2707)
 - Source
 - Why it matters
 
+Where they materially clarify a finding, entries should also record its current
+status, evidence level, production impact, Top 10 implication, last verification
+date, and links to primary sources.
+
 Anyone can add entries. Open a PR against this file with the same format.
 
 ---
 
 ## Entries
 
-### HAWK signature scheme, improved key recovery attack
+### HAWK signature scheme, improved key recovery attack and withdrawal
 
-- Date: 28 Jul 2026
-- Maps to: QS03, Vulnerable Signatures and Code-Signing
-- Summary: Anthropic researchers found a faster attack against HAWK, a NIST round-3 post-quantum signature candidate, using an AI model. It doesn't break HAWK outright, but it halves the effective key strength, so HAWK would need double the key size to hold its original security level. That wipes out most of the efficiency case for HAWK as a candidate.
-- Source: https://www.anthropic.com/research/discovering-cryptographic-weaknesses
-- Why it matters: HAWK isn't deployed anywhere, so no production impact today. But it's a live example of a PQC candidate getting weakened after two years of expert review, which is exactly the kind of algorithm-level risk QS03 needs to keep tracking as candidates move toward standardisation.
+- Published: 28 Jul 2026
+- Last verified: 3 Aug 2026
+- Status: Withdrawn from NIST's additional digital signature standardisation
+  process on 29 Jul 2026
+- Evidence: Demonstrated - paper, end-to-end implementation, coordinated
+  disclosure, and confirmation by the HAWK team
+- Maps to: Primary - QS03, Vulnerable Signatures and Code-Signing; secondary -
+  QS05, Crypto-Agility Failures
+- Summary: Anthropic researchers developed an improved key recovery attack
+  against HAWK, then a NIST round-3 post-quantum signature candidate. In the
+  paper's gate-count model, it lowers the estimated attack cost for HAWK-512 from
+  2^150 to 2^108 and for HAWK-1024 from 2^288 to 2^182. The researchers also
+  recovered a HAWK-256 secret key end to end in a few hours on one server. The
+  HAWK team confirmed that the attack approximately halves the lattice-reduction
+  block size required for key recovery and withdrew the candidate the following
+  day.
+- Production impact: None identified. HAWK was a candidate rather than a
+  deployed standard, and the attack does not transfer to Falcon, ML-DSA, or
+  lattice-based cryptography generally.
+- Top 10 implication: Supports QS03 by showing that post-quantum signature
+  candidates require continuing cryptanalysis, and QS05 by demonstrating why
+  systems must be able to change algorithms and parameters. It does not require
+  a new Top 10 category.
+- Sources:
+  - [Anthropic overview](https://www.anthropic.com/research/discovering-cryptographic-weaknesses)
+  - [HAWK-n Key Recovery Reduces to SVP in Dimension n/2 + 1](https://anthropic.com/document/hawk_key_recovery.pdf)
+  - [Demonstration implementation](https://github.com/anthropics/cryptography-research-demo)
+  - [Coordinated disclosure and HAWK team withdrawal](https://groups.google.com/a/list.nist.gov/g/pqc-forum/c/2r2u6SbHun4/m/0_I2KOZ_CQAJ)
+  - [NIST Round 3 additional signature candidates](https://csrc.nist.gov/projects/pqc-dig-sig/round-3-additional-signatures)
+- Why it matters: This is a complete example of the PQC review lifecycle:
+  expert-reviewed candidate, improved cryptanalysis, reproducible validation,
+  coordinated disclosure, and withdrawal before standardisation or deployment.
 
 ### CVE-2026-46344, heap overflow in liboqs OQS_MEM_aligned_alloc
 


### PR DESCRIPTION
## Summary

- update the HAWK entry with verified attack estimates and its 29 July withdrawal from the NIST process
- record evidence level, production impact, Top 10 implications, verification date, and primary references
- link the knowledge base from the project README

## Verification

- `git diff --check`
- confirmed all five external references return HTTP 200
- confirmed commit is unsigned (`git log` signature status `N`)

No code or runtime behavior is changed.