### PR TITLE
Add tooling directory for community-built tools, per Slack discussion

### DIFF
--- a/tooling/README.md
+++ b/tooling/README.md
@@ -1,0 +1,44 @@
+# Tooling
+
+The in-repo home for tools, proofs of concept, and utilities built and
+maintained by the OWASP Quantum Security Project community.
+
+The boundary with the [awesomelist](../awesomelist/) is build versus link: the
+awesomelist curates external resources; this directory holds work the project
+community contributes and maintains here. A tool that graduates to its own
+repository keeps an index entry below.
+
+## Index
+
+| Tool | Status | Maps to | Maintainer |
+|---|---|---|---|
+| Quantum Readiness Assessment | proposed - markdown-first self-assessment operationalising the migration-surface entries | QS01-QS07 | *open* |
+| QIR/LLVM circuit mapper | incoming - analyses LLVM bitcode / `.ll` files and maps quantum gates graphically, built on the QIR Alliance work | QS09 | Gabriel Ambroise (community) |
+
+Reference tooling developed by community members in their own repositories:
+
+- [pq-audit](https://github.com/mk-scorpiosec/pq-audit) - cryptographic
+  inventory across code, cloud/IaC, certificates, network, containers, and web3,
+  checked against FIPS 203/204/205, with JSON output for pipelines. Relevant to
+  QS04 (inventory and CBOM).
+
+## Contributing a tool
+
+1. Open a thread in `#project-quantum-security` describing the tool, or just
+   raise the pull request if it is already working.
+2. Add a subdirectory under `tooling/` containing the tool and a README that
+   states: what it does, which QS entries it operationalises, how to run it, and
+   its maturity (proof of concept, usable, maintained).
+3. Add a row to the index above, and state a named maintainer.
+
+Every tool should declare which Top 10 entries it maps to - the point of this
+directory is that the Top 10 stays operational rather than purely descriptive,
+which is the charter's Track 1 commitment.
+
+## Open question: code licensing
+
+The repository is licensed CC BY-SA 4.0, which suits documentation but is not
+designed for source code. Before substantial code lands here, the project leads
+may want to designate a standard code license for `tooling/` contents (Apache-2.0
+and MIT are the common OWASP choices), with CC BY-SA continuing to cover
+documentation. Flagged for decision rather than assumed.

--- a/tooling/README.md
+++ b/tooling/README.md
@@ -1,28 +1,38 @@
 # Tooling
 
-The in-repo home for tools, proofs of concept, and utilities built and
-maintained by the OWASP Quantum Security Project community.
+The home for tools that are **OWASP Quantum Security Project deliverables** -
+code authored as project output and living in this repository, not a directory
+of links to independently maintained external projects. That distinction is
+deliberate, per Roy's comment on the PR that opened this directory: this
+project does not audit or maintain external repositories, and listing one here
+would read as an endorsement or verification the project isn't in a position to
+give. Tools built and maintained by the community in their own repositories -
+however useful - belong on the [awesomelist](../awesomelist/), which exists
+precisely to curate external resources without implying OWASP maintains them.
+If you're looking for a tool someone else built, start there.
 
-The boundary with the [awesomelist](../awesomelist/) is build versus link: the
-awesomelist curates external resources; this directory holds work the project
-community contributes and maintains here. A tool that graduates to its own
-repository keeps an index entry below.
+**Sequencing:** general tooling work here follows the readiness guides, not the
+other way round - the Quantum Readiness Assessment is what makes the Top 10
+operational, and it comes first. This directory exists right now to hold that
+assessment and directly-contributed proofs of concept, not as a general tool
+marketplace.
+
+Presence in the index below states a tool's own declared maturity (proof of
+concept, usable, maintained) - it is not an OWASP quality certification, and
+readers should treat it as such regardless of maturity label.
 
 ## Index
 
 | Tool | Status | Maps to | Maintainer |
 |---|---|---|---|
 | Quantum Readiness Assessment | proposed - markdown-first self-assessment operationalising the migration-surface entries | QS01-QS07 | *open* |
-| QIR/LLVM circuit mapper | incoming - analyses LLVM bitcode / `.ll` files and maps quantum gates graphically, built on the QIR Alliance work | QS09 | Gabriel Ambroise (community) |
-
-Reference tooling developed by community members in their own repositories:
-
-- [pq-audit](https://github.com/mk-scorpiosec/pq-audit) - cryptographic
-  inventory across code, cloud/IaC, certificates, network, containers, and web3,
-  checked against FIPS 203/204/205, with JSON output for pipelines. Relevant to
-  QS04 (inventory and CBOM).
+| QIR/LLVM circuit mapper | incoming - proof of concept to be contributed directly into this repository, analysing LLVM bitcode / `.ll` files and mapping quantum gates graphically, built on the QIR Alliance work | QS09 | Gabriel Ambroise (community) |
 
 ## Contributing a tool
+
+Contributing here means contributing the tool's code into this repository (or
+formally adopting an existing one into it) - not adding a link to somewhere
+else it lives. For a link, use the awesomelist instead.
 
 1. Open a thread in `#project-quantum-security` describing the tool, or just
    raise the pull request if it is already working.


### PR DESCRIPTION
Creates the `tooling/` folder:

## What this adds

A single `tooling/README.md` establishing the directory:

- **Scope boundary with the awesomelist:** build versus link. The awesomelist
  curates external resources; `tooling/` holds work the community builds and
  maintains in-repo. A tool that graduates to its own repository keeps an index
  entry.
- **An index** mapping each tool to the QS entries it operationalises. Seeded
  with the QIR/LLVM circuit mapper Gabriel Ambroise described in the thread
  (listed as incoming, so the slot is ready when he is) and pq-audit as
  community reference tooling for QS04 inventory work.
- **Contribution steps:** describe the tool on Slack or just raise the PR, add a
  subdirectory with a README stating what it does, which QS entries it maps to,
  how to run it, and its maturity; add an index row with a named maintainer.

## Open question for the leads

The repository license is CC BY-SA 4.0, which suits documentation but is not
designed for source code. Before substantial code lands in `tooling/`, it may be
worth designating a standard code license for this directory's contents
(Apache-2.0 and MIT are the common choices), with CC BY-SA continuing to cover
documentation. Flagged for decision rather than assumed.

## Relationship to other work

A separate PR proposes the first resident tool - the markdown-first Quantum
Readiness Assessment from the charter's Track 1. The two are kept apart so this
directory-creation PR stays trivially mergeable; the index row for the
assessment updates once both land.