### PR TITLE
awesomelist: SLH-DSA is FIPS 205, not FIPS 204

### DIFF
--- a/awesomelist/README.md
+++ b/awesomelist/README.md
@@ -35,7 +35,7 @@ Tools and resources that assist with the creation of cryptographic inventories, 
 - [NIST PQC Standardisation Homepage](https://csrc.nist.gov/projects/post-quantum-cryptography) - Home page for NIST's PQC standardisation project.
 - [NIST Standard: ML-KEM](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.203.pdf) - FIPS 203, Module-Lattice-Based Key-Encapsulation Mechanism Standard (ML-KEM).
 - [NIST Standard: ML-DSA](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.204.pdf) - FIPS 204, Module-Lattice-Based Digital Signature Standard (ML-DSA).
-- [NIST Standard: SLH-DSA](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.205.pdf) - FIPS 204, Stateless Hash-Based Digital Signature Standard (SLH-DSA).
+- [NIST Standard: SLH-DSA](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.205.pdf) - FIPS 205, Stateless Hash-Based Digital Signature Standard (SLH-DSA).
 
 
 ## Test & Validation


### PR DESCRIPTION
The SLH-DSA entry labels the standard FIPS 204. FIPS 204 is ML-DSA, correctly labelled on the line directly above it. SLH-DSA is FIPS 205, which is also what the link on that line already points at, so this is the label catching up with the URL.